### PR TITLE
fix generated urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # NPM
 /node_modules
 npm-*
+localized-urls.json

--- a/bin/build-www-json
+++ b/bin/build-www-json
@@ -24,6 +24,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var url = require('url');
 var merge = require('lodash.merge');
 
 // -----------------------------------------------------------------------------
@@ -47,12 +48,12 @@ const allFilesSync = (dir, fileList = []) => {
 };
 
 const fileId = (dir, file) => {
-    return dir + '.' + path.parse(file).name + "Link" ;
+    return dir + '.' + path.parse(file).name + 'Link';
 };
 
 const bucketPath = (resource, locale, file) => {
     const bucketRoot = 'https://resources.scratch.mit.edu/www/';
-    return path.join(bucketRoot, resource, locale, file);
+    return url.resolve(bucketRoot, path.join(resource, locale, file));
 };
 
 const localeURL = (resource, locale, file) => {

--- a/resources/index.html
+++ b/resources/index.html
@@ -33,7 +33,8 @@
     // var BUCKET_NAME = 'scratch-resources';
     var BUCKET_URL = 'https://scratch-resources.s3.amazonaws.com';
     var BUCKET_WEBSITE_URL = 'https://resources.scratch.mit.edu';
-    var S3B_ROOT_DIR = 'source/';
+    //var S3B_ROOT_DIR = 'source/'; //use this to restrict browsing to the source folder
+    var S3B_ROOT_DIR = '';
     var S3B_SORT = 'A2Z';
     // var EXCLUDE_FILE = '.DS_Store';
     // var AUTO_TITLE = true;


### PR DESCRIPTION
use url.resolve instead of just path. Path takes out the double slash on the `https://`

I fixed a couple of lint issues as well.