### PR TITLE
Added 1 phrase to en.json tutorial words ("Let's party!")

### DIFF
--- a/resources/source/tutorials/tutorial-words/en.json
+++ b/resources/source/tutorials/tutorial-words/en.json
@@ -74,5 +74,9 @@
     "tutorials.score": {
         "message": "Score",
         "description": "This is the name of a variable that will be counting points in a game. Appears in Pong Game, Clicker Game, Chase Game, Make it Fly, and Animate an Adventure Game."
+    },
+    "tutorials.letsParty": {
+        "message": "Let's party!",
+        "description": "In the 'Getting Started' video tutorial, a dinosaur says this and then two dinosaurs dance. Doesn't need to be literal; could be 'Dance Party!', 'Party time!', 'Time to party!', or something similar."
     }
 }


### PR DESCRIPTION
Changes
- Added 1 phrase to en.json tutorial words, "Let's party!" 

Reason for the change: 
- This string appears in the Getting Started tutorial video, and now that we're beginning to produce some translated versions of the video, we'll need to use this string. 