### PR TITLE
Update circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ commands:
           name: Setup
           command: |
             npm install
+            npm run build
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Hotfix to fix missing `npm run build` step.
